### PR TITLE
Fixed newlines in text

### DIFF
--- a/app/Lib/Network/Email/PostmarkTransport.php
+++ b/app/Lib/Network/Email/PostmarkTransport.php
@@ -87,10 +87,10 @@ class PostmarkTransport extends AbstractTransport {
 	 */
 	private function __buildMessage() {
 
-        $eol = PHP_EOL;
-        if (isset($this->_config['eol'])) {
-            $eol = $this->_config['eol'];
-        }
+		$eol = PHP_EOL;
+		if (isset($this->_config['eol'])) {
+			$eol = $this->_config['eol'];
+		}
 
 		// Message
 		$message = array();
@@ -124,7 +124,7 @@ class PostmarkTransport extends AbstractTransport {
 		}
 
 		// TextBody
-        $message['TextBody'] = implode($eol, $this->_cakeEmail->message());
+		$message['TextBody'] = implode($eol, $this->_cakeEmail->message());
 
 		// Attachments
 		$message['Attachments'] = $this->__buildAttachments();


### PR DESCRIPTION
I kept wondering why my new lines "\n" were getting stripped out in my text emails. For a few days now, I thought it was a bug in Cake 2.0 (since it worked perfectly fine in 1.3).  But I found the culprit.

My fix was an observation made from Cake 2.0's default MailTransport (lib/Cake/Network/Email/MailTransport.php) file.  You'll notice they are doing the same thing before they send text emails, which is:

``` php
$eol = PHP_EOL; // The value is "\n" by default
if (isset($this->_config['eol'])) {
    $eol = $this->_config['eol'];
}
```

then

``` php
$message = implode($eol, $email->message());
```

New lines are now preserved when sending text emails with Postmark.
