### PR TITLE
Avoid setting a Reply-To: false header

### DIFF
--- a/Lib/Network/Email/PostmarkTransport.php
+++ b/Lib/Network/Email/PostmarkTransport.php
@@ -111,7 +111,9 @@ class PostmarkTransport extends AbstractTransport {
 		$message['Bcc'] = $this->_headers['Bcc'];
 
 		// ReplyTo
-		$message['ReplyTo'] = $this->_headers['Reply-To'];
+		if ($this->_headers['Reply-To'] !== false) {
+			$message['ReplyTo'] = $this->_headers['Reply-To'];
+		}
 
 		// Subject
 		$message['Subject'] = mb_decode_mimeheader($this->_headers['Subject']);


### PR DESCRIPTION
It's the default value set by CakeEmail::getHeaders and Postmark does include it in generated emails. This isn't a problem with the CC and BC fields as they default to empty strings instead.
