### PR TITLE
Ensure Content-ID is set for attachments

### DIFF
--- a/Lib/Network/Email/PostmarkTransport.php
+++ b/Lib/Network/Email/PostmarkTransport.php
@@ -159,6 +159,7 @@ class PostmarkTransport extends AbstractTransport {
 			$attachments[$i]['Name'] = $fileName;
 			$attachments[$i]['Content'] = $data;
 			$attachments[$i]['ContentType'] = $fileInfo['mimetype'];
+			$attachments[$i]['ContentId'] = $fileInfo['contentId'];
 
 			$i++;
 		}


### PR DESCRIPTION
Setting `content-id` as on option for attachments as per the [CakeEmail documentation](http://book.cakephp.org/2.0/en/core-utility-libraries/email.html#sending-attachments) wasn’t resulting in a `Content-ID` header. Without this header, `<img src="cid:foobar"/>` in HTML messages left a blank `src` attribute.

After adding this line, the `Content-Disposition` header also seems to automatically be set to `inline`, which I understand is important for inline images.

Please note that although this is working for me, I’m not overly familiar with this sort of thing and I can’t be sure that there aren’t other considerations which I’ve missed.

cc @domstubbs
