### PR TITLE
Added possibility to configure proxy for PostmarkTransport (HttpSocket)

### DIFF
--- a/Lib/Network/Email/PostmarkTransport.php
+++ b/Lib/Network/Email/PostmarkTransport.php
@@ -68,6 +68,9 @@ class PostmarkTransport extends AbstractTransport {
 		// Setup connection
 		$this->__postmarkConnection = & new HttpSocket();
 
+		// Configure transport
+		$this->__configure();
+
 		// Build message
 		$message = $this->__buildMessage();
 
@@ -87,6 +90,23 @@ class PostmarkTransport extends AbstractTransport {
 		}
 
 		return array_merge(array('Postmark' => $result), array('headers' => $headers, 'message' => $message));
+	}
+
+/**
+ * Configure transport. Currently only proxy setting is supported.
+ */
+	private function __configure() {
+		// Host is mandatory part of a proxy configuration
+		if (isset($this->_config['proxy']['host']) && !empty($this->_config['proxy']['host'])) {
+			$default = array(
+				'port' => 3128,
+				'method' => null,
+				'user' => null,
+				'pass' => null
+			);
+			$params = array_merge($default, $this->_config['proxy']);
+			$this->__postmarkConnection->configProxy($params['host'], $params['port'], $params['method'], $params['user'], $params['pass']);
+		}
 	}
 
 /**

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ _[Manual]_
 
 ## Configuration
 
-Bootstrap the plugin in app/Config/bootstrap.php:
+Bootstrap the plugin in `app/Config/bootstrap.php`:
 
 ```php
 CakePlugin::load('Postmark');
 ```
 
-Create the file app/Config/email.php with the class EmailConfig.
+Create the file `app/Config/email.php` with the class EmailConfig.
 
 ```php
 class EmailConfig {
@@ -87,6 +87,29 @@ Read more about [Open Tracking](http://blog.postmarkapp.com/post/87919491263/ope
 
 Note: Make sure to modified the API key to match the credentials for your Postmark server rack instance.
 
+## Proxy
+
+You can also configure a proxy in the file `app/Config/email.php`:
+
+```php
+class EmailConfig {
+  public $postmark = array(
+    'transport' => 'Postmark.Postmark',
+    'uri' => 'http://api.postmarkapp.com/email',
+    'key' => 'your-postmark-key',
+    'track_opens' => true,
+    'proxy' => array(
+      'host' => 'your-proxy-host', # Can be an array with settings to authentication class
+      'port' => 3128, # Default 3128
+      'method' => null, # Proxy method (ie, Basic, Digest). If empty, disable proxy authentication
+      'user' => null, # Username if your proxy need authentication
+      'pass' => null # Password to proxy authentication
+    ),
+  );
+}
+```
+
+Read more about [HttpSocket Parameters](https://api.cakephp.org/2.10/class-HttpSocket.html#_configProxy).
 
 ## Usage
 


### PR DESCRIPTION
Added simple possibility of configuring proxy for HttpSocket. It is safe and backwards compatible change.

A CakePHP configuration may look like:

```
<?php
class EmailConfig {

	public $postmark;

	public function __construct() {

		$this->postmark = array(
			'transport' => 'Postmark.Postmark',
			'uri' => POSTMARK_URI,
			'key' => POSTMARK_KEY,
			'proxy' => array(
				'host' => PROXY_HOST,
				'port' => PROXY_PORT,
			),
		);
    }
}
```

Thanks for any comment.
