### PR TITLE
Updated to work with PHP7 standards

### DIFF
--- a/Lib/Network/Email/PostmarkTransport.php
+++ b/Lib/Network/Email/PostmarkTransport.php
@@ -66,7 +66,7 @@ class PostmarkTransport extends AbstractTransport {
 		$this->_headers = $this->_cakeEmail->getHeaders(array('from', 'to', 'cc', 'bcc', 'replyTo', 'subject'));
 
 		// Setup connection
-		$this->__postmarkConnection = & new HttpSocket();
+		$this->__postmarkConnection = new HttpSocket();
 
 		// Configure transport
 		$this->__configure();


### PR DESCRIPTION
Create new HttpSocket object to be compatible with PHP7.

More at [Stack Overflow](https://stackoverflow.com/questions/38675762/parse-error-syntax-error-unexpected-new-t-new-in-test6-2-php-on-line-2#comment64731446_38675762)